### PR TITLE
[TT-7683] Add support for AWS SSM and Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - [TT-7683] Add support for AWS SSM and AWS Secrets Manager
+
 ## 0.4.0 (2020-05-20)
 
  - [TT-7323] Bring all dependencies up to date

--- a/lib/yamload/loader.rb
+++ b/lib/yamload/loader.rb
@@ -1,5 +1,8 @@
 require 'yaml'
 require 'ice_nine'
+require 'aws-sdk-secretsmanager'
+require 'aws-sdk-ssm'
+
 require 'yamload/loading'
 require 'yamload/conversion'
 require 'yamload/defaults'

--- a/spec/fixtures/erb.yml
+++ b/spec/fixtures/erb.yml
@@ -1,2 +1,4 @@
 ---
 erb_var: <%= 'ERB RAN!' %>
+ssm_var: <%= get_parameter 'ssm_var' %>
+secret_var: <%= get_secret 'secret_var' %>

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -32,8 +32,17 @@ describe Yamload::Loader do
   end
 
   context 'with a file containing ERB' do
+    before do
+      allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).
+        with({ name: 'ssm_var', with_decryption: true }).
+        and_return(double(parameter: double(value: 'SSM SUCCESS')))
+      allow_any_instance_of(Aws::SecretsManager::Client).to receive(:get_secret_value).
+        with({ secret_id: 'secret_var' }).
+        and_return(double(secret_string: 'SECRET SUCCESS'))
+    end
+
     let(:file) { :erb }
-    let(:expected_content) { { "erb_var" => "ERB RAN!" } }
+    let(:expected_content) { { "erb_var" => "ERB RAN!", "ssm_var" => "SSM SUCCESS", "secret_var" => "SECRET SUCCESS" } }
     specify { expect(loader).to exist }
     specify { expect(content).to eq expected_content }
   end

--- a/yamload.gemspec
+++ b/yamload.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'anima', '>= 0.2'
   spec.add_dependency 'facets', '>= 3.0'
+  spec.add_dependency 'aws-sdk-secretsmanager'
+  spec.add_dependency 'aws-sdk-ssm'
 
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '>= 10.0'


### PR DESCRIPTION
This allows us to rotate things like RDS keys without having to redeploy
the configs, it's just a simple server reboot.