### PR TITLE
[TT-7683] Add support for AWS SSM and Secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ notifications:
     secure: UInYCeoRfF7FEnNgW38nZDk3SXWfWN5rm+tKDWX/eWGIIUuynspe6A8776w+wG+9jSuzGt9J3WEIxxognkYiWmud96NYiKZIQDLx/6ql15A9jEvWwqnWbnaL4F368ujhwLo6V42Z6wRfTUqNeRQKki2WCw0NVmT6Y1bdTeNNy70=
 sudo: false
 cache: bundler
+env:
+  - AWS_REGION: us-east-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - [TT-7683] Add support for AWS SSM and AWS Secrets Manager
+
 ## 0.4.0 (2020-05-20)
 
  - [TT-7323] Bring all dependencies up to date

--- a/lib/yamload/loader.rb
+++ b/lib/yamload/loader.rb
@@ -1,5 +1,8 @@
 require 'yaml'
 require 'ice_nine'
+require 'aws-sdk-secretsmanager'
+require 'aws-sdk-ssm'
+
 require 'yamload/loading'
 require 'yamload/conversion'
 require 'yamload/defaults'

--- a/lib/yamload/loading/yaml.rb
+++ b/lib/yamload/loading/yaml.rb
@@ -33,13 +33,39 @@ module Yamload
 
       def erb_parsed_content
         raw_content = File.read(filepath, encoding: 'bom|utf-8', mode: 'r')
-        ERB.new(raw_content).result
+        ERB.new(raw_content).result(binding)
       end
 
       def filepath
         fail IOError, 'No yml files directory specified' if @dir.nil?
         fail IOError, "#{@dir} is not a valid directory" unless File.directory?(@dir)
         File.join(@dir, "#{@file}.yml")
+      end
+
+      def secrets_client
+        options = {}
+        options[:endpoint] = ENV['AWS_SECRETS_MANAGER_ENDPOINT'] if ENV.has_key?('AWS_SECRETS_MANAGER_ENDPOINT')
+        @secrets_client ||= Aws::SecretsManager::Client.new(options)
+      end
+
+      def get_secret(key)
+        secrets_client.get_secret_value(secret_id: key).secret_string
+      end
+
+      def ssm_client
+        options = {}
+        options[:endpoint] = ENV['AWS_SSM_ENDPOINT'] if ENV.has_key?('AWS_SSM_ENDPOINT')
+        @ssm_client ||= Aws::SSM::Client.new(options)
+      end
+
+      def get_parameter(key, encrypted: true)
+        ssm_client.get_parameter(
+          name: key,
+          with_decryption: encrypted
+        ).parameter.value
+      rescue Aws::SSM::Errors::ParameterNotFound => e
+        puts "Parameter #{key} not found"
+        raise e
       end
     end
   end

--- a/spec/fixtures/erb.yml
+++ b/spec/fixtures/erb.yml
@@ -1,2 +1,4 @@
 ---
 erb_var: <%= 'ERB RAN!' %>
+ssm_var: <%= get_parameter 'ssm_var' %>
+secret_var: <%= get_secret 'secret_var' %>

--- a/spec/fixtures/erb_bad.yml
+++ b/spec/fixtures/erb_bad.yml
@@ -1,0 +1,1 @@
+bad_key: <%= get_parameter 'bad_key' %>

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -32,8 +32,17 @@ describe Yamload::Loader do
   end
 
   context 'with a file containing ERB' do
+    before do
+      allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).
+        with({ name: 'ssm_var', with_decryption: true }).
+        and_return(double(parameter: double(value: 'SSM SUCCESS')))
+      allow_any_instance_of(Aws::SecretsManager::Client).to receive(:get_secret_value).
+        with({ secret_id: 'secret_var' }).
+        and_return(double(secret_string: 'SECRET SUCCESS'))
+    end
+
     let(:file) { :erb }
-    let(:expected_content) { { "erb_var" => "ERB RAN!" } }
+    let(:expected_content) { { "erb_var" => "ERB RAN!", "ssm_var" => "SSM SUCCESS", "secret_var" => "SECRET SUCCESS" } }
     specify { expect(loader).to exist }
     specify { expect(content).to eq expected_content }
   end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -45,6 +45,18 @@ describe Yamload::Loader do
     let(:expected_content) { { "erb_var" => "ERB RAN!", "ssm_var" => "SSM SUCCESS", "secret_var" => "SECRET SUCCESS" } }
     specify { expect(loader).to exist }
     specify { expect(content).to eq expected_content }
+
+    context 'with bad parameter key' do
+      before do
+        allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameter).
+          with({ name: 'bad_key', with_decryption: true }).
+          and_raise(Aws::SSM::Errors::ParameterNotFound.new(Seahorse, 'bad_key'))
+      end
+      let(:file) { :erb_bad }
+      specify {
+        expect { content }.to raise_error Aws::SSM::Errors::ParameterNotFound
+      }
+    end
   end
 
   context 'with a file defining an array' do

--- a/yamload.gemspec
+++ b/yamload.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'anima', '>= 0.2'
   spec.add_dependency 'facets', '>= 3.0'
+  spec.add_dependency 'aws-sdk-secretsmanager'
+  spec.add_dependency 'aws-sdk-ssm'
 
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '>= 10.0'


### PR DESCRIPTION
This allows us to rotate things like RDS keys without having to redeploy
the configs, it's just a simple server reboot.